### PR TITLE
Fix: 단어 카드 레이아웃 수정

### DIFF
--- a/frontend/src/components/VocaCard.tsx
+++ b/frontend/src/components/VocaCard.tsx
@@ -23,22 +23,28 @@ function VocaCard(props: {
                             alt="vocaImage"
                         />
                     </div>
-                    <div className={`relative rounded-xl object-cover w-full ${themeColor}`}>
-                        <div className="relative flex justify-center items-center font-ownglyph text-6xl py-10">
-                            <p className='flex'>
-                                {props.kor}
-                                <span className='font-Maplestory text-3xl ml-4 mt-3'>{props.other}</span>
-                                <img
-                                    className='w-8 h-8 ml-4 mt-4'
-                                    src="/img/speaker.png"
-                                    onClick={handleClick}
-                                />
-                            </p>
-                        </div>
-                        <p className='relative flex justify-center pb-10 font-ownglyph text-4xl'>
-                            {props.example}
-                        </p>
-                    </div>
+                    <div className={`relative rounded-xl object-cover w-full ${themeColor} flex flex-col items-center`}>
+    <div className="relative flex justify-center items-center font-ownglyph text-6xl py-10">
+        <p className='text-center'>
+            {props.kor}
+            <br />
+            <span className='font-Maplestory text-2xl mt-3'>
+                {props.other}
+            </span>
+        </p>
+        <img
+            className='w-8 h-8 ml-10 mt-2 cursor-pointer'
+            src="/img/speaker.png"
+            onClick={handleClick}
+            alt="speaker"
+        />
+    </div>
+    <p className='text-center pb-10 font-ownglyph text-3xl'>
+        {props.example}
+    </p>
+</div>
+
+
                 </div> 
             </figure>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
#34 

## 💡 핵심적으로 구현된 사항
<img width="1710" alt="image" src="https://github.com/BbobaVoca/BbobaVoca/assets/127101670/bfc371f9-05c8-4a2f-a01a-80e77acf4c9f">


- 단어 카드 레이아웃 수정
- 줄에 넘치지 않고 단어 크기 수정 및 줄바꿈

## ➕ 그 외에 추가적으로 구현된 사항
## 🤔 테스트,검증 && 고민 사항 